### PR TITLE
feat: addition of a new `colorize` option for disabling color/styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Main goal of this library is to provide relevant error messages like the followi
 - AJV 8 support.
 - Default errors stack the error message at the top of the location instead of the bottom.
   - This helps eliminate long blocks of `^^^^^^` pointers.
+- Addition of a `colorize` option for disabling colorization in `format: cli` output.
 - Up-to-date dependencies.
 
 ## Installation
@@ -80,6 +81,13 @@ Array of [ajv validation errors](https://github.com/epoberezkin/ajv#validation-e
 #### options
 
 Type: `Object`
+
+##### colorize
+
+Type: `boolean`
+Default: `true`
+
+When disabled, if you are outputting `cli` formatting it will be without colorized or styled content.
 
 ##### format
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -32,6 +32,19 @@ exports[`Main should output error with codeframe 1`] = `
 [0m [90m 6 |[39m[0m"
 `;
 
+exports[`Main should output error with reconstructed codeframe [without colors] 1`] = `
+"ENUM must be equal to one of the allowed values
+(paragraph, codeBlock, blockquote)
+
+  4 |   \\"content\\": [
+  5 |     {
+> 6 |       \\"type\\": \\"paragarph\\"
+    |               ^^^^^^^^^^^ 👈🏽  Did you mean paragraph here?
+  7 |     }
+  8 |   ]
+  9 | }"
+`;
+
 exports[`Main should output error with reconstructed codeframe 1`] = `
 "[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m

--- a/src/__tests__/helpers/create-error-instances.test.js
+++ b/src/__tests__/helpers/create-error-instances.test.js
@@ -26,6 +26,7 @@ describe('createErrorInstances', () => {
     expect(errors).toMatchInlineSnapshot(`
       Array [
         EnumValidationError {
+          "colorize": true,
           "data": undefined,
           "jsonAst": undefined,
           "jsonRaw": undefined,

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -6,7 +6,10 @@ import betterAjvErrorsBabelExport from '../../lib';
 import { openapi } from '@apidevtools/openapi-schemas';
 
 describe('Main', () => {
-  it('should output error with reconstructed codeframe', async () => {
+  it.each([
+    ['should output error with reconstructed codeframe', true],
+    ['should output error with reconstructed codeframe [without colors]', false],
+  ])('%s', async (_, colorize) => {
     const [schema, data] = await getSchemaAndData('default', __dirname);
     const ajv = new Ajv();
     const validate = ajv.compile(schema);
@@ -14,6 +17,7 @@ describe('Main', () => {
     expect(valid).toBe(false);
 
     const res = betterAjvErrors(schema, data, validate.errors, {
+      colorize,
       format: 'cli',
       indent: 2,
     });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import parse from 'json-to-ast';
 import prettify from './helpers';
 
 export default (schema, data, errors, options = {}) => {
-  const { format = 'cli', indent = null, json = null } = options;
+  const { colorize = true, format = 'cli', indent = null, json = null } = options;
 
   const jsonRaw = json || JSON.stringify(data, null, indent);
   const jsonAst = parse(jsonRaw, { loc: true });
@@ -10,6 +10,7 @@ export default (schema, data, errors, options = {}) => {
   const customErrorToText = error => error.print().join('\n');
   const customErrorToStructure = error => error.getError();
   const customErrors = prettify(errors, {
+    colorize,
     data,
     schema,
     jsonAst,

--- a/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Enum when value is a primitive prints correctly for empty value [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(foo, bar)
+",
+  "> 1 | \\"baz\\"
+    | ^^^^^ 👈🏽  Did you mean bar here?",
+]
+`;
+
 exports[`Enum when value is a primitive prints correctly for empty value 1`] = `
 Array [
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
@@ -7,6 +17,16 @@ Array [
 ",
   "[0m[31m[1m>[22m[39m[90m 1 |[39m [32m\\"baz\\"[39m[0m
 [0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m",
+]
+`;
+
+exports[`Enum when value is a primitive prints correctly for enum prop [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(foo, bar)
+",
+  "> 1 | \\"baz\\"
+    | ^^^^^ 👈🏽  Did you mean bar here?",
 ]
 `;
 
@@ -20,6 +40,16 @@ Array [
 ]
 `;
 
+exports[`Enum when value is a primitive prints correctly for no levenshtein match [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(one, two)
+",
+  "> 1 | \\"baz\\"
+    | ^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values",
+]
+`;
+
 exports[`Enum when value is a primitive prints correctly for no levenshtein match 1`] = `
 Array [
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
@@ -27,6 +57,18 @@ Array [
 ",
   "[0m[31m[1m>[22m[39m[90m 1 |[39m [32m\\"baz\\"[39m[0m
 [0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Unexpected value, should be equal to one of the allowed values[22m[39m[0m",
+]
+`;
+
+exports[`Enum when value is an object prints correctly for empty value [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(foo, bar)
+",
+  "  1 | {
+> 2 |   \\"id\\": \\"baz\\"
+    |         ^^^^^ 👈🏽  Did you mean bar here?
+  3 | }",
 ]
 `;
 
@@ -42,6 +84,18 @@ Array [
 ]
 `;
 
+exports[`Enum when value is an object prints correctly for enum prop [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(foo, bar)
+",
+  "  1 | {
+> 2 |   \\"id\\": \\"baz\\"
+    |         ^^^^^ 👈🏽  Did you mean bar here?
+  3 | }",
+]
+`;
+
 exports[`Enum when value is an object prints correctly for enum prop 1`] = `
 Array [
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
@@ -51,6 +105,18 @@ Array [
 [0m[31m[1m>[22m[39m[90m 2 |[39m   [32m\\"id\\"[39m[33m:[39m [32m\\"baz\\"[39m[0m
 [0m [90m   |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m
 [0m [90m 3 |[39m }[0m",
+]
+`;
+
+exports[`Enum when value is an object prints correctly for no levenshtein match [without colors] 1`] = `
+Array [
+  "ENUM should be equal to one of the allowed values",
+  "(one, two)
+",
+  "  1 | {
+> 2 |   \\"id\\": \\"baz\\"
+    |         ^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
+  3 | }",
 ]
 `;
 

--- a/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
@@ -10,3 +10,14 @@ Array [
 [0m [90m 3 |[39m }[0m",
 ]
 `;
+
+exports[`Required prints correctly for missing required prop[without colors] 1`] = `
+Array [
+  "REQUIRED should have required property 'id'
+",
+  "  1 | {
+> 2 |   \\"nested\\": {}
+    |             ^ ☹️  id is missing here!
+  3 | }",
+]
+`;

--- a/src/validation-errors/__tests__/enum.test.js
+++ b/src/validation-errors/__tests__/enum.test.js
@@ -15,7 +15,10 @@ describe('Enum', () => {
       jsonAst = parse(jsonRaw, { loc: true });
     });
 
-    it('prints correctly for enum prop', () => {
+    it.each([
+      ['prints correctly for enum prop', true],
+      ['prints correctly for enum prop [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -24,13 +27,16 @@ describe('Enum', () => {
           params: { allowedValues: ['foo', 'bar'] },
           message: `should be equal to one of the allowed values`,
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print()).toMatchSnapshot();
     });
 
-    it('prints correctly for no levenshtein match', () => {
+    it.each([
+      ['prints correctly for no levenshtein match', true],
+      ['prints correctly for no levenshtein match [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -39,13 +45,16 @@ describe('Enum', () => {
           params: { allowedValues: ['one', 'two'] },
           message: `should be equal to one of the allowed values`,
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print()).toMatchSnapshot();
     });
 
-    it('prints correctly for empty value', () => {
+    it.each([
+      ['prints correctly for empty value', true],
+      ['prints correctly for empty value [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -54,7 +63,7 @@ describe('Enum', () => {
           params: { allowedValues: ['foo', 'bar'] },
           message: `should be equal to one of the allowed values`,
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print(schema, { id: '' })).toMatchSnapshot();
@@ -73,7 +82,10 @@ describe('Enum', () => {
       jsonAst = parse(jsonRaw, { loc: true });
     });
 
-    it('prints correctly for enum prop', () => {
+    it.each([
+      ['prints correctly for enum prop', true],
+      ['prints correctly for enum prop [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -84,13 +96,16 @@ describe('Enum', () => {
           },
           message: 'should be equal to one of the allowed values',
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print()).toMatchSnapshot();
     });
 
-    it('prints correctly for no levenshtein match', () => {
+    it.each([
+      ['prints correctly for no levenshtein match', true],
+      ['prints correctly for no levenshtein match [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -101,13 +116,16 @@ describe('Enum', () => {
           },
           message: 'should be equal to one of the allowed values',
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print()).toMatchSnapshot();
     });
 
-    it('prints correctly for empty value', () => {
+    it.each([
+      ['prints correctly for empty value', true],
+      ['prints correctly for empty value [without colors]', false],
+    ])('%s', (_, colorize) => {
       const error = new EnumValidationError(
         {
           keyword: 'enum',
@@ -118,7 +136,7 @@ describe('Enum', () => {
           },
           message: 'should be equal to one of the allowed values',
         },
-        { data, schema, jsonRaw, jsonAst }
+        { colorize, data, schema, jsonRaw, jsonAst }
       );
 
       expect(error.print(schema, '')).toMatchSnapshot();

--- a/src/validation-errors/__tests__/required.test.js
+++ b/src/validation-errors/__tests__/required.test.js
@@ -3,7 +3,10 @@ import { getSchemaAndData } from '../../test-helpers';
 import RequiredValidationError from '../required';
 
 describe('Required', () => {
-  it('prints correctly for missing required prop', async () => {
+  it.each([
+    ['prints correctly for missing required prop', true],
+    ['prints correctly for missing required prop[without colors]', false],
+  ])('%s', async (_, colorize) => {
     const [schema, data] = await getSchemaAndData('required', __dirname);
     const jsonRaw = JSON.stringify(data, null, 2);
     const jsonAst = parse(jsonRaw, { loc: true });
@@ -16,7 +19,7 @@ describe('Required', () => {
         params: { missingProperty: 'id' },
         message: `should have required property 'id'`,
       },
-      { data, schema, jsonRaw, jsonAst }
+      { colorize, data, schema, jsonRaw, jsonAst }
     );
 
     expect(error.print()).toMatchSnapshot();

--- a/src/validation-errors/additional-prop.js
+++ b/src/validation-errors/additional-prop.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import BaseValidationError from './base';
 
 export default class AdditionalPropValidationError extends BaseValidationError {
@@ -10,6 +9,7 @@ export default class AdditionalPropValidationError extends BaseValidationError {
 
   print() {
     const { message, params } = this.options;
+    const chalk = this.getChalk();
     const output = [chalk`{red {bold ADDTIONAL PROPERTY} ${message}}\n`];
 
     return output.concat(

--- a/src/validation-errors/base.js
+++ b/src/validation-errors/base.js
@@ -1,13 +1,19 @@
+import chalk from 'chalk';
 import { codeFrameColumns } from '@babel/code-frame';
 import { getMetaFromPath, getDecoratedDataPath } from '../json';
 
 export default class BaseValidationError {
-  constructor(options = { isIdentifierLocation: false }, { data, schema, jsonAst, jsonRaw }) {
+  constructor(options = { isIdentifierLocation: false }, { colorize, data, schema, jsonAst, jsonRaw }) {
     this.options = options;
+    this.colorize = !!(!!colorize || colorize === undefined);
     this.data = data;
     this.schema = schema;
     this.jsonAst = jsonAst;
     this.jsonRaw = jsonRaw;
+  }
+
+  getChalk() {
+    return this.colorize ? chalk : new chalk.Instance({ level: 0 });
   }
 
   getLocation(dataPath = this.instancePath) {
@@ -25,7 +31,7 @@ export default class BaseValidationError {
 
   getCodeFrame(message, dataPath = this.instancePath) {
     return codeFrameColumns(this.jsonRaw, this.getLocation(dataPath), {
-      highlightCode: true,
+      highlightCode: this.colorize,
       message,
     });
   }

--- a/src/validation-errors/default.js
+++ b/src/validation-errors/default.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import BaseValidationError from './base';
 
 export default class DefaultValidationError extends BaseValidationError {
@@ -10,6 +9,7 @@ export default class DefaultValidationError extends BaseValidationError {
 
   print() {
     const { keyword, message } = this.options;
+    const chalk = this.getChalk();
     const output = [chalk`{red {bold ${keyword.toUpperCase()}} ${message}}\n`];
 
     return output.concat(this.getCodeFrame(chalk`👈🏽  {magentaBright ${keyword}} ${message}`));

--- a/src/validation-errors/enum.js
+++ b/src/validation-errors/enum.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import leven from 'leven';
 import pointer from 'jsonpointer';
 import BaseValidationError from './base';
@@ -14,6 +13,7 @@ export default class EnumValidationError extends BaseValidationError {
       message,
       params: { allowedValues },
     } = this.options;
+    const chalk = this.getChalk();
     const bestMatch = this.findBestMatch();
 
     const output = [chalk`{red {bold ENUM} ${message}}`, chalk`{red (${allowedValues.join(', ')})}\n`];

--- a/src/validation-errors/required.js
+++ b/src/validation-errors/required.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import BaseValidationError from './base';
 
 export default class RequiredValidationError extends BaseValidationError {
@@ -14,6 +13,7 @@ export default class RequiredValidationError extends BaseValidationError {
 
   print() {
     const { message, params } = this.options;
+    const chalk = this.getChalk();
     const output = [chalk`{red {bold REQUIRED} ${message}}\n`];
 
     return output.concat(this.getCodeFrame(chalk`☹️  {magentaBright ${params.missingProperty}} is missing here!`));


### PR DESCRIPTION
This adds a new `colorize` option that allows for disabling [chalk](https://npm.im/chalk) usage in error output.