### PR TITLE
feat: improved handling for `pattern` errors and `patternProperties` cases

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,9 +11,10 @@ import {
 } from './utils';
 import {
   AdditionalPropValidationError,
-  RequiredValidationError,
-  EnumValidationError,
   DefaultValidationError,
+  EnumValidationError,
+  PatternValidationError,
+  RequiredValidationError,
   UnevaluatedPropValidationError,
 } from './validation-errors';
 
@@ -110,6 +111,8 @@ export function createErrorInstances(root, options) {
       switch (error.keyword) {
         case 'additionalProperties':
           return ret.concat(new AdditionalPropValidationError(error, options));
+        case 'pattern':
+          return ret.concat(new PatternValidationError(error, options));
         case 'required':
           return ret.concat(new RequiredValidationError(error, options));
         case 'unevaluatedProperties':

--- a/src/validation-errors/__fixtures__/patternProperties/data.json
+++ b/src/validation-errors/__fixtures__/patternProperties/data.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Security scheme component with spaces in it",
+    "version": "v1.0.0"
+  },
+  "security": [
+    {
+      "Basic Access Authentication": ["read", "write"]
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "Basic Access Authentication": {
+        "type": "apiKey",
+        "name": "API-TOKEN",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/src/validation-errors/__fixtures__/patternProperties/schema.json
+++ b/src/validation-errors/__fixtures__/patternProperties/schema.json
@@ -1,0 +1,3 @@
+{
+  "//": "load  `@apidevtools/openapi-schemas` instead for this test case"
+}

--- a/src/validation-errors/__tests__/__snapshots__/main.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/main.test.js.snap
@@ -54,6 +54,35 @@ Array [
 ]
 `;
 
+exports[`Main should support js output format for patternProperties errors 1`] = `
+Array [
+  Object {
+    "end": Object {
+      "column": 261,
+      "line": 1,
+      "offset": 260,
+    },
+    "error": "/components/securitySchemes Property \\"Basic Access Authentication\\" must match pattern ^[a-zA-Z0-9._-]+$",
+    "path": "/components/securitySchemes",
+    "start": Object {
+      "column": 244,
+      "line": 1,
+      "offset": 243,
+    },
+  },
+  Object {
+    "end": undefined,
+    "error": "/components/securitySchemes: propertyNames property name must be valid",
+    "path": "/components/securitySchemes",
+    "start": Object {
+      "column": 262,
+      "line": 1,
+      "offset": 261,
+    },
+  },
+]
+`;
+
 exports[`Main should support js output format for required errors 1`] = `
 Array [
   Object {

--- a/src/validation-errors/__tests__/main.test.js
+++ b/src/validation-errors/__tests__/main.test.js
@@ -1,6 +1,7 @@
 import Ajv from 'ajv/dist/2020';
 import betterAjvErrors from '../..';
 import { getSchemaAndData } from '../../test-helpers';
+import { openapi } from '@apidevtools/openapi-schemas';
 
 describe('Main', () => {
   it('should support js output format for default errors', async () => {
@@ -35,6 +36,25 @@ describe('Main', () => {
     const [schema, data] = await getSchemaAndData('additionalProperties', __dirname);
 
     const ajv = new Ajv();
+    const validate = ajv.compile(schema);
+    const valid = validate(data);
+    expect(valid).toBe(false);
+
+    const res = betterAjvErrors(schema, data, validate.errors, {
+      format: 'js',
+    });
+    expect(res).toMatchSnapshot();
+  });
+
+  // Though this is testing `patternProperties` cases, the error that'll come back will just be for `pattern` since
+  // that's what `patternPropeties` utilizes in the schema.
+  it('should support js output format for patternProperties errors', async () => {
+    const [, data] = await getSchemaAndData('patternProperties', __dirname);
+
+    // The OpenAPI 3.1 schema has a good example of this for component names so we're using that instead of writing
+    // our own.
+    const schema = openapi.v31;
+    const ajv = new Ajv({ allErrors: true, strict: false, validateFormats: false });
     const validate = ajv.compile(schema);
     const valid = validate(data);
     expect(valid).toBe(false);

--- a/src/validation-errors/additional-prop.js
+++ b/src/validation-errors/additional-prop.js
@@ -10,7 +10,7 @@ export default class AdditionalPropValidationError extends BaseValidationError {
   print() {
     const { message, params } = this.options;
     const chalk = this.getChalk();
-    const output = [chalk`{red {bold ADDTIONAL PROPERTY} ${message}}\n`];
+    const output = [chalk`{red {bold ADDITIONAL PROPERTY} ${message}}\n`];
 
     return output.concat(
       this.getCodeFrame(

--- a/src/validation-errors/index.js
+++ b/src/validation-errors/index.js
@@ -1,5 +1,6 @@
-export { default as RequiredValidationError } from './required';
 export { default as AdditionalPropValidationError } from './additional-prop';
-export { default as EnumValidationError } from './enum';
 export { default as DefaultValidationError } from './default';
+export { default as EnumValidationError } from './enum';
+export { default as PatternValidationError } from './pattern';
+export { default as RequiredValidationError } from './required';
 export { default as UnevaluatedPropValidationError } from './unevaluated-prop';

--- a/src/validation-errors/pattern.js
+++ b/src/validation-errors/pattern.js
@@ -1,0 +1,33 @@
+import BaseValidationError from './base';
+
+export default class PatternValidationError extends BaseValidationError {
+  constructor(...args) {
+    super(...args);
+    this.name = 'PatternValidationError';
+    this.options.isIdentifierLocation = true;
+  }
+
+  print() {
+    const { message, params, propertyName } = this.options;
+    const chalk = this.getChalk();
+    const output = [chalk`{red {bold PROPERTY} ${message}}\n`];
+
+    return output.concat(
+      this.getCodeFrame(
+        chalk`😲  must match pattern {magentaBright ${params.pattern}}`,
+        `${this.instancePath}/${propertyName}`
+      )
+    );
+  }
+
+  getError() {
+    const { params, propertyName } = this.options;
+
+    return {
+      // ...this.getLocation(`${this.instancePath}/${params.propertyName}`),
+      ...this.getLocation(),
+      error: `${this.getDecoratedPath()} Property "${propertyName}" must match pattern ${params.pattern}`,
+      path: this.instancePath,
+    };
+  }
+}


### PR DESCRIPTION
## 🧰 Changes

This adds improved handling for `pattern` errors that happen with `patternProperties` cases, like in the case of the OpenAPI 3.1 schema requiring component schemas to be formatted a specific way.

## 🧬 QA & Testing

Prior to this work this is what this error would be reported as:

![Screen Shot 2021-12-17 at 12 46 34 PM](https://user-images.githubusercontent.com/33762/146606597-c6e90924-1660-4085-88c9-66c54b60eefd.png)

And now:

![Screen Shot 2021-12-17 at 12 46 48 PM](https://user-images.githubusercontent.com/33762/146606611-4d128894-0f07-4ba5-95e9-61103e807560.png)

You can ignore the second error in both as I haven't touched that and with work I'm doing in `@readme/openapi-parser` that error will get filtered out in favor of surfacing the `pattern` error to the user.