### PR TITLE
fix: don't highlight code examples in returned error messages

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -4,32 +4,32 @@ exports[`Main Babel export should function as normal 1`] = `
 "[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
-[0m[31m[1m>[22m[39m[90m 1 |[39m {[32m"type"[39m[33m:[39m[32m"doc"[39m[33m,[39m[32m"version"[39m[33m:[39m[35m1[39m[33m,[39m[32m"content"[39m[33m:[39m[{[32m"type"[39m[33m:[39m[32m"paragarph"[39m}]}[0m
-[0m [90m   |[39m                                              [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mparagraph[31m here?[22m[39m[0m"
+> 1 | {"type":"doc","version":1,"content":[{"type":"paragarph"}]}
+    |                                              ^^^^^^^^^^^ 👈🏽  Did you mean [95mparagraph[39m here?"
 `;
 
 exports[`Main complex schema examples should output an error on an invalid OpenAPI 3.1 definition 1`] = `
 "[31m[1mUNEVALUATED PROPERTY[22m[39m[31m must NOT have unevaluated properties[39m
 
-[0m [90m 15 |[39m         [32m"summary"[39m[33m:[39m [32m"Example operation"[39m[33m,[39m[0m
-[0m [90m 16 |[39m         [32m"description"[39m[33m:[39m [32m"This operation has \`tags\` typod."[39m[33m,[39m[0m
-[0m[31m[1m>[22m[39m[90m 17 |[39m         [32m"tagss"[39m[33m:[39m [[0m
-[0m [90m    |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m😲  [95mtagss[31m is not expected to be here![22m[39m[0m
-[0m [90m 18 |[39m           [32m"Tag Name"[39m[0m
-[0m [90m 19 |[39m         ][33m,[39m[0m
-[0m [90m 20 |[39m         [32m"responses"[39m[33m:[39m {[0m"
+  15 |         "summary": "Example operation",
+  16 |         "description": "This operation has \`tags\` typod.",
+> 17 |         "tagss": [
+     |         ^^^^^^^ 😲  [95mtagss[39m is not expected to be here!
+  18 |           "Tag Name"
+  19 |         ],
+  20 |         "responses": {"
 `;
 
 exports[`Main should output error with codeframe 1`] = `
 "[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
-[0m [90m 2 |[39m   [32m"type"[39m[33m:[39m [32m"doc"[39m[33m,[39m[0m
-[0m [90m 3 |[39m   [32m"version"[39m[33m:[39m [35m1[39m[33m,[39m[0m
-[0m[31m[1m>[22m[39m[90m 4 |[39m   [32m"content"[39m[33m:[39m [{ [32m"type"[39m[33m:[39m [32m"paragarph"[39m }][0m
-[0m [90m   |[39m                         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mparagraph[31m here?[22m[39m[0m
-[0m [90m 5 |[39m }[0m
-[0m [90m 6 |[39m[0m"
+  2 |   "type": "doc",
+  3 |   "version": 1,
+> 4 |   "content": [{ "type": "paragarph" }]
+    |                         ^^^^^^^^^^^ 👈🏽  Did you mean [95mparagraph[39m here?
+  5 | }
+  6 |"
 `;
 
 exports[`Main should output error with reconstructed codeframe [without colors] 1`] = `
@@ -49,11 +49,11 @@ exports[`Main should output error with reconstructed codeframe 1`] = `
 "[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
-[0m [90m 4 |[39m   [32m"content"[39m[33m:[39m [[0m
-[0m [90m 5 |[39m     {[0m
-[0m[31m[1m>[22m[39m[90m 6 |[39m       [32m"type"[39m[33m:[39m [32m"paragarph"[39m[0m
-[0m [90m   |[39m               [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mparagraph[31m here?[22m[39m[0m
-[0m [90m 7 |[39m     }[0m
-[0m [90m 8 |[39m   ][0m
-[0m [90m 9 |[39m }[0m"
+  4 |   "content": [
+  5 |     {
+> 6 |       "type": "paragarph"
+    |               ^^^^^^^^^^^ 👈🏽  Did you mean [95mparagraph[39m here?
+  7 |     }
+  8 |   ]
+  9 | }"
 `;

--- a/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
@@ -15,8 +15,8 @@ exports[`Enum when value is a primitive prints correctly for empty value 1`] = `
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
-  "[0m[31m[1m>[22m[39m[90m 1 |[39m [32m"baz"[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m",
+  "> 1 | "baz"
+    | ^^^^^ 👈🏽  Did you mean [95mbar[39m here?",
 ]
 `;
 
@@ -35,8 +35,8 @@ exports[`Enum when value is a primitive prints correctly for enum prop 1`] = `
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
-  "[0m[31m[1m>[22m[39m[90m 1 |[39m [32m"baz"[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m",
+  "> 1 | "baz"
+    | ^^^^^ 👈🏽  Did you mean [95mbar[39m here?",
 ]
 `;
 
@@ -55,8 +55,8 @@ exports[`Enum when value is a primitive prints correctly for no levenshtein matc
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(one, two)[39m
 ",
-  "[0m[31m[1m>[22m[39m[90m 1 |[39m [32m"baz"[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Unexpected value, should be equal to one of the allowed values[22m[39m[0m",
+  "> 1 | "baz"
+    | ^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values",
 ]
 `;
 
@@ -77,10 +77,10 @@ exports[`Enum when value is an object prints correctly for empty value 1`] = `
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
-  "[0m [90m 1 |[39m {[0m
-[0m[31m[1m>[22m[39m[90m 2 |[39m   [32m"id"[39m[33m:[39m [32m"baz"[39m[0m
-[0m [90m   |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m
-[0m [90m 3 |[39m }[0m",
+  "  1 | {
+> 2 |   "id": "baz"
+    |         ^^^^^ 👈🏽  Did you mean [95mbar[39m here?
+  3 | }",
 ]
 `;
 
@@ -101,10 +101,10 @@ exports[`Enum when value is an object prints correctly for enum prop 1`] = `
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
-  "[0m [90m 1 |[39m {[0m
-[0m[31m[1m>[22m[39m[90m 2 |[39m   [32m"id"[39m[33m:[39m [32m"baz"[39m[0m
-[0m [90m   |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Did you mean [95mbar[31m here?[22m[39m[0m
-[0m [90m 3 |[39m }[0m",
+  "  1 | {
+> 2 |   "id": "baz"
+    |         ^^^^^ 👈🏽  Did you mean [95mbar[39m here?
+  3 | }",
 ]
 `;
 
@@ -125,9 +125,9 @@ exports[`Enum when value is an object prints correctly for no levenshtein match 
   "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
   "[31m(one, two)[39m
 ",
-  "[0m [90m 1 |[39m {[0m
-[0m[31m[1m>[22m[39m[90m 2 |[39m   [32m"id"[39m[33m:[39m [32m"baz"[39m[0m
-[0m [90m   |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m👈🏽  Unexpected value, should be equal to one of the allowed values[22m[39m[0m
-[0m [90m 3 |[39m }[0m",
+  "  1 | {
+> 2 |   "id": "baz"
+    |         ^^^^^ 👈🏽  Unexpected value, should be equal to one of the allowed values
+  3 | }",
 ]
 `;

--- a/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
@@ -4,10 +4,10 @@ exports[`Required prints correctly for missing required prop 1`] = `
 [
   "[31m[1mREQUIRED[22m[39m[31m should have required property 'id'[39m
 ",
-  "[0m [90m 1 |[39m {[0m
-[0m[31m[1m>[22m[39m[90m 2 |[39m   [32m"nested"[39m[33m:[39m {}[0m
-[0m [90m   |[39m             [31m[1m^[22m[39m [31m[1m☹️  [95mid[31m is missing here![22m[39m[0m
-[0m [90m 3 |[39m }[0m",
+  "  1 | {
+> 2 |   "nested": {}
+    |             ^ ☹️  [95mid[39m is missing here!
+  3 | }",
 ]
 `;
 

--- a/src/validation-errors/base.js
+++ b/src/validation-errors/base.js
@@ -33,7 +33,19 @@ export default class BaseValidationError {
 
   getCodeFrame(message, dataPath = this.instancePath) {
     return codeFrameColumns(this.jsonRaw, this.getLocation(dataPath), {
-      highlightCode: this.colorize,
+      /**
+       * `@babel/highlight`, by way of `@babel/code-frame`, highlights out entire block of raw JSON
+       * instead of just our `location` block -- so if you have a block of raw JSON that's upwards
+       * of 2mb+ and have a lot of errors to generate code frames for then we're re-highlighting
+       * the same huge chunk of code over and over and over and over again, all just so
+       * `@babel/code-frame` will eventually extract a small <10 line chunk out of it to return to
+       * us.
+       *
+       * Disabling `highlightCode` here will only disable highlighting the code we're showing users;
+       * if `options.colorize` is supplied to this library then the error message we're adding will
+       * still be highlighted.
+       */
+      highlightCode: false,
       message,
     });
   }


### PR DESCRIPTION
## 🧰 Changes

When supplied with a very large file, that has a very large amount of errors, returning errors can take upwards of **minutes** due to the code highlighting work in `@babel/highlight` (way way of `@babel/code-frame`) highlighting our supplied file for each error supplied.

For example on an OpenAPI definition that is 2MB+, that also has 20 errors, simply rendering our our errors took up to 21 seconds. Without this code highlighting work? 2 seconds.

![screen_shot_2023-03-24_at_4 21 39_pm](https://user-images.githubusercontent.com/33762/227815166-82ec7136-f147-4abd-9e5a-0baa7a735c0d.png)
