### PR TITLE
feat: swapping `chalk` out for `picocolors`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,6 @@ updates:
       - dependency-name: '@humanwhocodes/momoa'
         versions:
           - '>= 3'
-      - dependency-name: chalk
-        versions:
-          - '>= 5'
       - dependency-name: leven
         versions:
           - '>= 4'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@babel/code-frame": "^7.22.5",
         "@babel/runtime": "^7.22.5",
         "@humanwhocodes/momoa": "^2.0.3",
-        "chalk": "^4.1.2",
         "jsonpointer": "^5.0.0",
-        "leven": "^3.1.0"
+        "leven": "^3.1.0",
+        "picocolors": "^1.1.1"
       },
       "devDependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
@@ -3335,6 +3335,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3878,6 +3879,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3968,6 +3970,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3978,7 +3981,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "6.2.1",
@@ -6447,6 +6451,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9126,6 +9131,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11996,6 +12002,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -12349,6 +12356,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12404,6 +12412,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -12411,7 +12420,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "commander": {
       "version": "6.2.1",
@@ -14087,7 +14097,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.2",
@@ -15873,6 +15884,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "@babel/code-frame": "^7.22.5",
     "@babel/runtime": "^7.22.5",
     "@humanwhocodes/momoa": "^2.0.3",
-    "chalk": "^4.1.2",
     "jsonpointer": "^5.0.0",
-    "leven": "^3.1.0"
+    "leven": "^3.1.0",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@apidevtools/openapi-schemas": "^2.1.0",

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Main > Babel export > should function as normal 1`] = `
-"[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
+"[31m[1mENUM[22m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
 > 1 | {"type":"doc","version":1,"content":[{"type":"paragarph"}]}

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ exports[`Main > Babel export > should function as normal 1`] = `
 `;
 
 exports[`Main > complex schema examples > should output an error on an invalid OpenAPI 3.1 definition 1`] = `
-"[31m[1mUNEVALUATED PROPERTY[22m[39m[31m must NOT have unevaluated properties[39m
+"[31m[1mUNEVALUATED PROPERTY[22m must NOT have unevaluated properties[39m
 
   15 |         "summary": "Example operation",
   16 |         "description": "This operation has \`tags\` typod.",
@@ -21,7 +21,7 @@ exports[`Main > complex schema examples > should output an error on an invalid O
 `;
 
 exports[`Main > should output error with codeframe 1`] = `
-"[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
+"[31m[1mENUM[22m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
   2 |   "type": "doc",
@@ -46,7 +46,7 @@ exports[`Main > should output error with reconstructed codeframe [without colors
 `;
 
 exports[`Main > should output error with reconstructed codeframe 1`] = `
-"[31m[1mENUM[22m[39m[31m must be equal to one of the allowed values[39m
+"[31m[1mENUM[22m must be equal to one of the allowed values[39m
 [31m(paragraph, codeBlock, blockquote)[39m
 
   4 |   "content": [

--- a/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/enum.test.js.snap
@@ -12,7 +12,7 @@ exports[`Enum > when value is a primitive > prints correctly for empty value [wi
 
 exports[`Enum > when value is a primitive > prints correctly for empty value 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
   "> 1 | "baz"
@@ -32,7 +32,7 @@ exports[`Enum > when value is a primitive > prints correctly for enum prop [with
 
 exports[`Enum > when value is a primitive > prints correctly for enum prop 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
   "> 1 | "baz"
@@ -52,7 +52,7 @@ exports[`Enum > when value is a primitive > prints correctly for no levenshtein 
 
 exports[`Enum > when value is a primitive > prints correctly for no levenshtein match 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(one, two)[39m
 ",
   "> 1 | "baz"
@@ -74,7 +74,7 @@ exports[`Enum > when value is an object > prints correctly for empty value [with
 
 exports[`Enum > when value is an object > prints correctly for empty value 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
   "  1 | {
@@ -98,7 +98,7 @@ exports[`Enum > when value is an object > prints correctly for enum prop [withou
 
 exports[`Enum > when value is an object > prints correctly for enum prop 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(foo, bar)[39m
 ",
   "  1 | {
@@ -122,7 +122,7 @@ exports[`Enum > when value is an object > prints correctly for no levenshtein ma
 
 exports[`Enum > when value is an object > prints correctly for no levenshtein match 1`] = `
 [
-  "[31m[1mENUM[22m[39m[31m should be equal to one of the allowed values[39m",
+  "[31m[1mENUM[22m should be equal to one of the allowed values[39m",
   "[31m(one, two)[39m
 ",
   "  1 | {

--- a/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
+++ b/src/validation-errors/__tests__/__snapshots__/required.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Required > prints correctly for missing required prop 1`] = `
 [
-  "[31m[1mREQUIRED[22m[39m[31m should have required property 'id'[39m
+  "[31m[1mREQUIRED[22m should have required property 'id'[39m
 ",
   "  1 | {
 > 2 |   "nested": {}

--- a/src/validation-errors/additional-prop.js
+++ b/src/validation-errors/additional-prop.js
@@ -9,12 +9,12 @@ export default class AdditionalPropValidationError extends BaseValidationError {
 
   print() {
     const { message, params } = this.options;
-    const chalk = this.getChalk();
-    const output = [chalk`{red {bold ADDITIONAL PROPERTY} ${message}}\n`];
+    const colorizer = this.getColorize();
+    const output = [`${colorizer.red(`${colorizer.bold('ADDITIONAL PROPERTY')} ${message}`)}\n`];
 
     return output.concat(
       this.getCodeFrame(
-        chalk`😲  {magentaBright ${params.additionalProperty}} is not expected to be here!`,
+        `😲  ${colorizer.magentaBright(params.additionalProperty)} is not expected to be here!`,
         `${this.instancePath}/${params.additionalProperty}`,
       ),
     );

--- a/src/validation-errors/base.js
+++ b/src/validation-errors/base.js
@@ -1,5 +1,5 @@
 import { codeFrameColumns } from '@babel/code-frame';
-import chalk from 'chalk';
+import pc from 'picocolors';
 
 import { getMetaFromPath, getDecoratedDataPath } from '../json';
 
@@ -14,8 +14,20 @@ export default class BaseValidationError {
     this.jsonRaw = jsonRaw;
   }
 
-  getChalk() {
-    return this.colorize ? chalk : new chalk.Instance({ level: 0 });
+  getColorizer() {
+    return this.colorize
+      ? pc
+      : // `picocolors` doesn't have a way to programatically disable the library so we're
+        // creating an empty proxy that'll just return the arguments of any color functions we
+        // invoke, sans any colorization.
+        new Proxy(
+          {},
+          {
+            get() {
+              return arg => arg;
+            },
+          },
+        );
   }
 
   getLocation(dataPath = this.instancePath) {

--- a/src/validation-errors/default.js
+++ b/src/validation-errors/default.js
@@ -9,10 +9,10 @@ export default class DefaultValidationError extends BaseValidationError {
 
   print() {
     const { keyword, message } = this.options;
-    const chalk = this.getChalk();
-    const output = [chalk`{red {bold ${keyword.toUpperCase()}} ${message}}\n`];
+    const colorizer = this.getColorizer();
+    const output = [`${colorizer.red(`${colorizer.bold(keyword.toUpperCase())} ${message}`)}\n`];
 
-    return output.concat(this.getCodeFrame(chalk`👈🏽  {magentaBright ${keyword}} ${message}`));
+    return output.concat(this.getCodeFrame(`👈🏽  ${colorizer.magentaBright(keyword)} ${message}`));
   }
 
   getError() {

--- a/src/validation-errors/enum.js
+++ b/src/validation-errors/enum.js
@@ -14,16 +14,19 @@ export default class EnumValidationError extends BaseValidationError {
       message,
       params: { allowedValues },
     } = this.options;
-    const chalk = this.getChalk();
+    const colorizer = this.getColorizer();
     const bestMatch = this.findBestMatch();
 
-    const output = [chalk`{red {bold ENUM} ${message}}`, chalk`{red (${allowedValues.join(', ')})}\n`];
+    const output = [
+      `${colorizer.red(`${colorizer.bold('ENUM')} ${message}`)}`,
+      `${colorizer.red(`(${allowedValues.join(', ')})`)}\n`,
+    ];
 
     return output.concat(
       this.getCodeFrame(
         bestMatch !== null
-          ? chalk`👈🏽  Did you mean {magentaBright ${bestMatch}} here?`
-          : chalk`👈🏽  Unexpected value, should be equal to one of the allowed values`,
+          ? `👈🏽  Did you mean ${colorizer.magentaBright(bestMatch)} here?`
+          : '👈🏽  Unexpected value, should be equal to one of the allowed values',
       ),
     );
   }

--- a/src/validation-errors/pattern.js
+++ b/src/validation-errors/pattern.js
@@ -9,12 +9,12 @@ export default class PatternValidationError extends BaseValidationError {
 
   print() {
     const { message, params, propertyName } = this.options;
-    const chalk = this.getChalk();
-    const output = [chalk`{red {bold PROPERTY} ${message}}\n`];
+    const colorizer = this.getColorizer();
+    const output = [`${colorizer.red(`${colorizer.bold('PROPERTY')} ${message}`)}\n`];
 
     return output.concat(
       this.getCodeFrame(
-        chalk`😲  must match pattern {magentaBright ${params.pattern}}`,
+        `😲  must match pattern ${colorizer.magentaBright(params.pattern)}`,
         `${this.instancePath}/${propertyName}`,
       ),
     );

--- a/src/validation-errors/required.js
+++ b/src/validation-errors/required.js
@@ -13,10 +13,10 @@ export default class RequiredValidationError extends BaseValidationError {
 
   print() {
     const { message, params } = this.options;
-    const chalk = this.getChalk();
-    const output = [chalk`{red {bold REQUIRED} ${message}}\n`];
+    const colorizer = this.getColorizer();
+    const output = [`${colorizer.red(`${colorizer.bold('REQUIRED')} ${message}`)}\n`];
 
-    return output.concat(this.getCodeFrame(chalk`☹️  {magentaBright ${params.missingProperty}} is missing here!`));
+    return output.concat(this.getCodeFrame(`☹️  ${colorizer.magentaBright(params.missingProperty)} is missing here!`));
   }
 
   getError() {

--- a/src/validation-errors/unevaluated-prop.js
+++ b/src/validation-errors/unevaluated-prop.js
@@ -9,12 +9,12 @@ export default class UnevaluatedPropValidationError extends BaseValidationError 
 
   print() {
     const { message, params } = this.options;
-    const chalk = this.getChalk();
-    const output = [chalk`{red {bold UNEVALUATED PROPERTY} ${message}}\n`];
+    const colorizer = this.getColorizer();
+    const output = [`${colorizer.red(`${colorizer.bold('UNEVALUATED PROPERTY')} ${message}`)}\n`];
 
     return output.concat(
       this.getCodeFrame(
-        chalk`😲  {magentaBright ${params.unevaluatedProperty}} is not expected to be here!`,
+        `😲  ${colorizer.magentaBright(params.unevaluatedProperty)} is not expected to be here!`,
         `${this.instancePath}/${params.unevaluatedProperty}`,
       ),
     );


### PR DESCRIPTION
## 🧰 Changes

This swaps out [chalk](https://npm.im/chalk) for [picocolors](https://npm.im/picocolors) as our colorizing library of choice.

Why? Not only is Chalk pretty bulky for what we need, but also `@babel/code-frame` uses it for code syntax highlighting. We programatically disable code syntax highlighting in that library but because treeshakers aren't smart enough to understand that it still gets compiled into client bundles. Swapping `chalk` out for `picocolors` allows us to take advantage of that, reducing a good 40kB+ of overhead.

## 🧬 QA & Testing

The differences of bold text between `chalk` and `picocolors` is slightly different but they visually look identical.
